### PR TITLE
Samples project files and header path corrections for Linux.

### DIFF
--- a/samples/AlignmentSample/linux/CMakeLists.txt
+++ b/samples/AlignmentSample/linux/CMakeLists.txt
@@ -1,0 +1,52 @@
+# AlignmentSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( AlignmentSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/AlignmentSampleApp.cpp
+    ${SRC_DIR}/AlignmentSample.cpp
+    ${SRC_DIR}/Indicator.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/AlignmentSample/linux/cibuild
+++ b/samples/AlignmentSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/AnimationSample/linux/CMakeLists.txt
+++ b/samples/AnimationSample/linux/CMakeLists.txt
@@ -1,0 +1,53 @@
+# AnimationSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( AnimationSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/AnimationSampleApp.cpp
+    ${SRC_DIR}/AnimationSample.cpp
+    ${SRC_DIR}/AnimationSquare.cpp
+    ${SRC_DIR}/Indicator.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/AnimationSample/linux/cibuild
+++ b/samples/AnimationSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/BoundsSample/linux/CMakeLists.txt
+++ b/samples/BoundsSample/linux/CMakeLists.txt
@@ -1,0 +1,51 @@
+# BoundsSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( BoundsSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/BoundsSampleApp.cpp
+    ${SRC_DIR}/BoundsSample.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/BoundsSample/linux/cibuild
+++ b/samples/BoundsSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/HierarchySample/linux/CMakeLists.txt
+++ b/samples/HierarchySample/linux/CMakeLists.txt
@@ -1,0 +1,52 @@
+# HierarchySample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( HierarchySample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/HierarchySampleApp.cpp
+    ${SRC_DIR}/HierarchySample.cpp
+    ${SRC_DIR}/Square.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/HierarchySample/linux/cibuild
+++ b/samples/HierarchySample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/MaskingSample/linux/CMakeLists.txt
+++ b/samples/MaskingSample/linux/CMakeLists.txt
@@ -1,0 +1,51 @@
+# MaskingSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( MaskingSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/MaskingSampleApp.cpp
+    ${SRC_DIR}/MaskingSample.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/MaskingSample/linux/cibuild
+++ b/samples/MaskingSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/MaskingSample/src/MaskingSample.cpp
+++ b/samples/MaskingSample/src/MaskingSample.cpp
@@ -1,5 +1,5 @@
 #include "MaskingSample.h"
-#include "cinder/imageIo.h"
+#include "cinder/ImageIo.h"
 
 //	photo credit: <a href="http://www.flickr.com/photos/37539977@N00/600757415">slowly getting into the box</a> via <a href="http://photopin.com">photopin</a> <a href="https://creativecommons.org/licenses/by/2.0/">(license)</a>
 

--- a/samples/MouseEventsSample/linux/CMakeLists.txt
+++ b/samples/MouseEventsSample/linux/CMakeLists.txt
@@ -1,0 +1,53 @@
+# MouseEventsSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( MouseEventsSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/MouseEventsSampleApp.cpp
+    ${SRC_DIR}/MouseEventsSample.cpp
+    ${SRC_DIR}/Indicator.cpp
+    ${SRC_DIR}/Square.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/MouseEventsSample/linux/cibuild
+++ b/samples/MouseEventsSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/ShapeTextureSample/linux/CMakeLists.txt
+++ b/samples/ShapeTextureSample/linux/CMakeLists.txt
@@ -1,0 +1,52 @@
+# ShapeTextureSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( ShapeTextureSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/ShapeTextureSampleApp.cpp
+    ${SRC_DIR}/ShapeTextureSample.cpp
+    ${SRC_DIR}/Indicator.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/ShapeTextureSample/linux/cibuild
+++ b/samples/ShapeTextureSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/ShapeTextureSample/src/ShapeTextureSample.cpp
+++ b/samples/ShapeTextureSample/src/ShapeTextureSample.cpp
@@ -1,5 +1,5 @@
 #include "ShapeTextureSample.h"
-#include "cinder/imageIo.h"
+#include "cinder/ImageIo.h"
 
 ShapeTextureSampleRef ShapeTextureSample::create() 
 {

--- a/samples/TextSample/linux/CMakeLists.txt
+++ b/samples/TextSample/linux/CMakeLists.txt
@@ -1,0 +1,51 @@
+# TextSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( TextSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/TextSampleApp.cpp
+    ${SRC_DIR}/TextSample.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/TextSample/linux/cibuild
+++ b/samples/TextSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/TextSampleAdvanced/linux/CMakeLists.txt
+++ b/samples/TextSampleAdvanced/linux/CMakeLists.txt
@@ -1,0 +1,53 @@
+# TextSampleAdvanced
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( TextSampleAdvanced )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/TextSampleAdvancedApp.cpp
+    ${SRC_DIR}/TextSampleAdvanced.cpp
+    ${SRC_DIR}/TextComponent.cpp
+    ${SRC_DIR}/Scroller.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/TextSampleAdvanced/linux/cibuild
+++ b/samples/TextSampleAdvanced/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/VideoSample/linux/CMakeLists.txt
+++ b/samples/VideoSample/linux/CMakeLists.txt
@@ -1,0 +1,52 @@
+# VideoSample
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( VideoSample )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/VideoSampleApp.cpp
+    ${SRC_DIR}/VideoSample.cpp
+    ${SRC_DIR}/PlayerNode.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/VideoSample/linux/cibuild
+++ b/samples/VideoSample/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/VideoSample/src/VideoSample.cpp
+++ b/samples/VideoSample/src/VideoSample.cpp
@@ -1,7 +1,7 @@
 #include "cinder/qtime/QuickTimeGl.h"
 #include "VideoSample.h"
 #include "poShape.h"
-#include "cinder/imageIo.h"
+#include "cinder/ImageIo.h"
 #include "cinder/Utilities.h"
 
 using namespace po::scene;

--- a/samples/VideoSampleAdvanced/linux/CMakeLists.txt
+++ b/samples/VideoSampleAdvanced/linux/CMakeLists.txt
@@ -1,0 +1,55 @@
+# VideoSampleAdvanced
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE on )
+
+get_filename_component( CINDER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+include( ${CINDER_DIR}/linux/cmake/Cinder.cmake )
+
+project( VideoSampleAdvanced )
+
+get_filename_component( PO_SCENE_BLOCK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../src" ABSOLUTE )
+get_filename_component( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src" ABSOLUTE )
+get_filename_component( INC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include" ABSOLUTE )
+
+if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
+    find_package( cinder REQUIRED
+        PATHS ${PROJECT_SOURCE_DIR}/../../../../../linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+        $ENV{Cinder_DIR}/linux/${CMAKE_BUILD_TYPE}/${CINDER_OUT_DIR_PREFIX}
+    )
+endif()
+
+# Use PROJECT_NAME since CMAKE_PROJET_NAME returns the top-level project name.
+set( EXE_NAME ${PROJECT_NAME} )
+
+set( PO_SCENE_SRC ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNode.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poNodeContainer.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poMatrixSet.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poImage.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEvents.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poEventCenter.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poTextBox.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poShape.cpp
+                  ${PO_SCENE_BLOCK_SRC_DIR}/poScene/poScene.cpp
+                  )
+set( SRC_FILES
+    ${SRC_DIR}/VideoSampleAdvancedApp.cpp
+    ${SRC_DIR}/VideoSampleAdvanced.cpp
+    ${SRC_DIR}/PlayerController.cpp
+    ${SRC_DIR}/PlayerButton.cpp
+    ${SRC_DIR}/MovieThumb.cpp
+    ${SRC_DIR}/Scrubber.cpp
+    ${PO_SCENE_SRC}
+)
+
+add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+target_include_directories(
+	"${EXE_NAME}"
+    PUBLIC ${INC_DIR} 
+           ${SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}
+           ${PO_SCENE_BLOCK_SRC_DIR}/poScene
+           
+)
+
+target_link_libraries( "${EXE_NAME}" cinder${CINDER_LIB_SUFFIX} )

--- a/samples/VideoSampleAdvanced/linux/cibuild
+++ b/samples/VideoSampleAdvanced/linux/cibuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../../../../tools/linux/cibuilder -app "$@"

--- a/samples/VideoSampleAdvanced/src/PlayerController.cpp
+++ b/samples/VideoSampleAdvanced/src/PlayerController.cpp
@@ -1,6 +1,6 @@
 #include "PlayerController.h"
 #include "poShape.h"
-#include "cinder/imageIo.h"
+#include "cinder/ImageIo.h"
 #include "cinder/qtime/QuickTime.h"
 using namespace po::scene;
 

--- a/src/poScene/poShape.h
+++ b/src/poScene/poShape.h
@@ -36,7 +36,7 @@
 #include "cinder/gl/Vbo.h"
 #include "cinder/gl/VboMesh.h"
 #include "cinder/gl/draw.h"
-#include "cinder/gl/shader.h"
+#include "cinder/gl/Shader.h"
 #include "cinder/gl/scoped.h"
 
 namespace po { namespace scene {

--- a/src/poScene/poVideo.h
+++ b/src/poScene/poVideo.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "cinder/qtime/QuickTime.h"
-#ifndef CINDER_MSW
+#if ! defined(  CINDER_MSW ) && ! defined( CINDER_LINUX )
     #include "cinder/qtime/QuickTimeGlImplAvf.h"
 #endif
 #include "cinder/qtime/QuickTimeGl.h"


### PR DESCRIPTION
Hi! 

Thanks for this block. Looks great! This PR adds project files for running the samples on Linux and corrects some header paths ( e.g cinder/imageIo.h vs cinder/ImageIo.h ) that seem to pass from Xcode/VS but not from gcc/clang on Linux.