### PR TITLE
Shape stroke

### DIFF
--- a/samples/HierarchySample/src/Square.cpp
+++ b/samples/HierarchySample/src/Square.cpp
@@ -37,6 +37,8 @@ void Square::setup(int size)
 	mHighlightColor = ci::Color(ci::CM_HSV, 1 - hue, 1, 1);
 	
 	mShape->setFillColor(mColor);
+	mShape->setStrokeColor(ci::Color::black());
+	mShape->setStrokeEnabled(true);
 	addChild(mShape);
 	
 	//	Connect to mouse events

--- a/src/poScene/poNode.cpp
+++ b/src/poScene/poNode.cpp
@@ -113,6 +113,7 @@ namespace po { namespace scene {
     , mFillEnabled(true)
     , mStrokeColor(255, 255, 255)
     , mStrokeEnabled(false)
+    , mStrokeSize(2.f)
     , mPixelSnapping(false)
     , mUpdatePositionFromAnim(false)
     , mUpdateScaleFromAnim(false)

--- a/src/poScene/poNode.h
+++ b/src/poScene/poNode.h
@@ -372,10 +372,14 @@ namespace po { namespace scene {
         Node &setStrokeColor(float r, float g, float b) { mStrokeColor = ci::Color(r, g, b); return *this;}
         //! Enable or disable the stroke
         Node &setStrokeEnabled(bool enabled) { mStrokeEnabled = enabled; return *this; };
+        //! Set the stroke size with a pixel amount
+        Node &setStrokeSize(float size) { mStrokeSize = size; return *this; }
         //! Get stroke enabled
         bool getStrokeEnabled() { return mStrokeEnabled; }
         //! Get the stroke color
         ci::Color getStrokeColor() { return mStrokeColor; }
+        //! Set the stroke color (convenience method)
+        float &getStrokeSize() { return mStrokeSize; }
         
         // Caching/FBO
         // Nodes can be cached to an FBO. This is generally useful when applying a shader to a whole node,
@@ -511,6 +515,7 @@ namespace po { namespace scene {
         ci::Color mFillColor;
         ci::Color mStrokeColor;
         bool mFillEnabled, mStrokeEnabled;
+        float mStrokeSize;
         float mAlpha, mAppliedAlpha;
         MatrixOrder mMatrixOrder;
         

--- a/src/poScene/poShape.cpp
+++ b/src/poScene/poShape.cpp
@@ -175,6 +175,26 @@ namespace po { namespace scene {
     
     void Shape::draw()
     {
+        if(getStrokeEnabled()) {
+            ci::Rectf b = getBounds();
+            float s = getStrokeSize();
+            ci::vec2 scale =
+                ci::vec2((b.getWidth() + s * 2.f) / b.getWidth(), (b.getHeight() + s * 2.f) / b.getHeight());
+            
+            ci::gl::color(ci::Color(getStrokeColor()));
+            // Scale up by 2 times stroke size pixels.
+            ci::gl::scale(scale);
+            
+            // Translate it so that the main shape is centered.
+            ci::gl::translate(-s, -s);
+            ci::gl::ScopedGlslProg shaderScp( ci::gl::getStockShader( ci::gl::ShaderDef().color()));
+            ci::gl::draw(mVboMesh);
+            
+            // Remember to scale and translate back before drawing the main shape.
+            ci::gl::scale(ci::vec2(1.0f) / scale);
+            ci::gl::translate(s, s);
+        }
+        
         //Draw fill
         if (getFillEnabled()) {
             ci::gl::enableAlphaBlending();
@@ -189,8 +209,6 @@ namespace po { namespace scene {
                 ci::gl::draw(mVboMesh);
             }
         }
-        
-        //	TODO: Draw stroke
     }
     
     


### PR DESCRIPTION
This is a crude approximation for shape stroke. It scales up the
mesh  and translates it to get the stroke size on either side of
the shape and draws a colored shape before the main version is drawn.