### PR TITLE
Make all signal connections scope safe

### DIFF
--- a/src/poScene/DragAndDrop.h
+++ b/src/poScene/DragAndDrop.h
@@ -60,5 +60,7 @@ private:
 	void viewDragBeganHandler(po::scene::DraggableViewRef &view);
 	void viewDraggedHandler(po::scene::DraggableViewRef &view);
 	void viewDragEndedHandler(po::scene::DraggableViewRef &view);
+
+	ci::signals::ConnectionList mConnections;
 };
 }}

--- a/src/poScene/DraggableView.h
+++ b/src/poScene/DraggableView.h
@@ -49,5 +49,6 @@ namespace po { namespace scene {
 
 		bool mSnapsBack;
 		ci::vec2 mSnapPosition;
+		ci::signals::ConnectionList	mConnections;
 	};
 }}

--- a/src/poScene/EventCenter.h
+++ b/src/poScene/EventCenter.h
@@ -149,11 +149,11 @@ namespace po { namespace scene {
 		MouseEventProcessor() {};
 
 		void connectEvents() override {
-			ci::app::getWindow()->getSignalMouseDown().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::DOWN,	std::placeholders::_1));
-			ci::app::getWindow()->getSignalMouseMove().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::MOVE,	std::placeholders::_1));
-			ci::app::getWindow()->getSignalMouseDrag().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::DRAG,	std::placeholders::_1));
-			ci::app::getWindow()->getSignalMouseUp().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::UP,		std::placeholders::_1));
-			ci::app::getWindow()->getSignalMouseWheel().connect(std::bind(&MouseEventProcessor::addToQueue, this, MouseEvent::Type::WHEEL,	std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalMouseDown().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::DOWN,	std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalMouseMove().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::MOVE,	std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalMouseDrag().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::DRAG,	std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalMouseUp().connect(std::bind(&MouseEventProcessor::addToQueue,	this, MouseEvent::Type::UP,		std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalMouseWheel().connect(std::bind(&MouseEventProcessor::addToQueue, this, MouseEvent::Type::WHEEL,	std::placeholders::_1));
 		}
 
         void notifyCallbacks(std::vector<ViewRef> &views, MouseEvent &event) override
@@ -182,7 +182,10 @@ namespace po { namespace scene {
                 
             event.setType(callbackType);
             EventProcessor::notifyCallbacks(views, event);
-        }	
+        }
+
+	private:
+		ci::signals::ConnectionList	mConnections;
     };
 
 
@@ -196,9 +199,9 @@ namespace po { namespace scene {
 	public:
 		void connectEvents() override {
 			//	Connect touch events
-			ci::app::getWindow()->getSignalTouchesBegan().connect(std::bind(&TouchEventProcessor::addToQueue, this, TouchEvent::Type::BEGAN, std::placeholders::_1));
-			ci::app::getWindow()->getSignalTouchesMoved().connect(std::bind(&TouchEventProcessor::addToQueue, this, TouchEvent::Type::MOVED, std::placeholders::_1));
-			ci::app::getWindow()->getSignalTouchesEnded().connect(std::bind(&TouchEventProcessor::addToQueue, this, TouchEvent::Type::ENDED, std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalTouchesBegan().connect(std::bind(&TouchEventProcessor::addToQueue, this, TouchEvent::Type::BEGAN, std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalTouchesMoved().connect(std::bind(&TouchEventProcessor::addToQueue, this, TouchEvent::Type::MOVED, std::placeholders::_1));
+			mConnections += ci::app::getWindow()->getSignalTouchesEnded().connect(std::bind(&TouchEventProcessor::addToQueue, this, TouchEvent::Type::ENDED, std::placeholders::_1));
 		}
 
 		//	Needs to break about grouped touches from Cinder
@@ -235,6 +238,8 @@ namespace po { namespace scene {
 			event.setType(callbackType);
 			EventProcessor::notifyCallbacks(views, event);
 		}
+
+		ci::signals::ConnectionList	mConnections;
 	};
     
 } } //	namespace po::scene

--- a/src/poScene/Scene.h
+++ b/src/poScene/Scene.h
@@ -137,6 +137,8 @@ namespace po { namespace scene {
         void resetFbos();
         ci::gl::FboRef mFbo;
         ci::gl::FboRef mMaskFbo;
+
+        ci::signals::ScopedConnection	mConnWindowResize;
     };
 	
 } } //  namespace po::scene

--- a/src/poScene/_DragAndDrop.cpp
+++ b/src/poScene/_DragAndDrop.cpp
@@ -81,9 +81,9 @@ namespace po { namespace scene {
 
 		mDraggableViews.push_back(view);
 
-		view->getSignalDragBegan().connect(std::bind(&DragAndDropViewController::viewDragBeganHandler, this, std::placeholders::_1));
-		view->getSignalDragged().connect(std::bind(&DragAndDropViewController::viewDraggedHandler, this, std::placeholders::_1));
-		view->getSignalDragEnded().connect(std::bind(&DragAndDropViewController::viewDragEndedHandler, this, std::placeholders::_1));
+		mConnections += view->getSignalDragBegan().connect(std::bind(&DragAndDropViewController::viewDragBeganHandler, this, std::placeholders::_1));
+		mConnections += view->getSignalDragged().connect(std::bind(&DragAndDropViewController::viewDraggedHandler, this, std::placeholders::_1));
+		mConnections += view->getSignalDragEnded().connect(std::bind(&DragAndDropViewController::viewDragEndedHandler, this, std::placeholders::_1));
 	}
 
 	void DragAndDropViewController::trackDropZoneView(DropZoneViewRef view) {

--- a/src/poScene/_DraggableView.cpp
+++ b/src/poScene/_DraggableView.cpp
@@ -45,9 +45,9 @@ namespace po { namespace scene {
 
 	void DraggableView::connectEvents() {
 		// Attach drag events
-		getSignal(po::scene::MouseEvent::DOWN_INSIDE).connect(std::bind(&DraggableView::mouseEventHandler, this, std::placeholders::_1));
-		getSignal(po::scene::MouseEvent::DRAG).connect(std::bind(&DraggableView::mouseEventHandler, this, std::placeholders::_1));
-		getSignal(po::scene::MouseEvent::UP).connect(std::bind(&DraggableView::mouseEventHandler, this, std::placeholders::_1));
+		mConnections += getSignal(po::scene::MouseEvent::DOWN_INSIDE).connect(std::bind(&DraggableView::mouseEventHandler, this, std::placeholders::_1));
+		mConnections += getSignal(po::scene::MouseEvent::DRAG).connect(std::bind(&DraggableView::mouseEventHandler, this, std::placeholders::_1));
+		mConnections += getSignal(po::scene::MouseEvent::UP).connect(std::bind(&DraggableView::mouseEventHandler, this, std::placeholders::_1));
 	}
 
 	void DraggableView::mouseEventHandler(po::scene::MouseEvent &event) {

--- a/src/poScene/_Scene.cpp
+++ b/src/poScene/_Scene.cpp
@@ -55,7 +55,7 @@ namespace po { namespace scene {
     , mMaskFbo(nullptr)
     {
         createFbos();
-        ci::app::getWindow()->getSignalResize().connect(std::bind(&Scene::createFbos, this));
+        mConnWindowResize = ci::app::getWindow()->getSignalResize().connect(std::bind(&Scene::createFbos, this));
     }
     
     Scene::~Scene()


### PR DESCRIPTION
Uses new signals::ConnectionList where appropriate.

Requires https://github.com/cinder/Cinder/pull/1676, so probably shouldn't be merged until that gets its due process.