### PR TITLE
add methods to ScrollViewDelegate for scrolling start and movement

### DIFF
--- a/src/poScene/ui/ScrollView.h
+++ b/src/poScene/ui/ScrollView.h
@@ -17,6 +17,8 @@ namespace po
 			class ScrollViewDelegate
 			{
 				public:
+					virtual void didStartScrolling( ScrollViewRef scrollView ) = 0;
+					virtual void didScroll( ScrollViewRef scrollView ) = 0;
 					virtual void didFinishScrolling( ScrollViewRef scrollView ) = 0;
 			};
 

--- a/src/poScene/ui/_ScrollView.cpp
+++ b/src/poScene/ui/_ScrollView.cpp
@@ -132,6 +132,11 @@ namespace po
 					mCurEventPos = pos;
 					mPrevEventPos = pos;
 				}
+
+				if( !mDelegate.expired() ) {
+					ScrollViewRef self = std::dynamic_pointer_cast<ScrollView>( shared_from_this() );
+					mDelegate.lock()->didStartScrolling( self );
+				}
 			}
 
 			void ScrollView::eventMoved( int id, ci::vec2 pos )
@@ -154,6 +159,12 @@ namespace po
 
 					mContentView->setPosition( newPos );
 
+
+
+					if( !mDelegate.expired() ) {
+						ScrollViewRef self = std::dynamic_pointer_cast<ScrollView>( shared_from_this() );
+						mDelegate.lock()->didScroll( self );
+					}
 
 					//ci::app::console() << "Drag Pos: " << pos << std::endl;
 				}
@@ -183,7 +194,7 @@ namespace po
 					ci::vec2 targetPos = mContentView->getPosition() + throwDistance;
 
 					mScrollTargetPos = getSnapPos( targetPos );
-					
+
 					/*
 					ci::app::console() << "----------------------------------------" << std::endl;
 					ci::app::console() << "Pos: " << pos << std::endl;
@@ -192,7 +203,7 @@ namespace po
 					ci::app::console() << "Throw Distance: " << throwDistance << std::endl;
 					ci::app::console() << "Scroll View Content Size: " << mContentView->getSize() << std::endl;
 					*/
-					
+
 					// Cleanup
 					mIsScrolling = false;
 					mEventId = -1;


### PR DESCRIPTION
We needed to get more information about the state of the ScrollView, so I introduced some more methods to the delegate to signal the start of scrolling, as well as its state on every move/drag event.