### PR TITLE
bug fixes and small features

### DIFF
--- a/src/poScene/View.cpp
+++ b/src/poScene/View.cpp
@@ -92,7 +92,8 @@ namespace po
 			vec4 alphaValue     = texture( mask, c0 );
 
 			color.rgb     = rgbValue.rgb;
-			color.a       = alphaValue.a * rgbValue.a;
+			// same as GL_ONE, GL_ONE_MINUS_SRC_ALPHA
+			color.a       = alphaValue.a  + alphaValue.a * ( 1.0 - rgbValue.a );
 		}
 		                                           );
 

--- a/src/poScene/View.cpp
+++ b/src/poScene/View.cpp
@@ -132,6 +132,7 @@ namespace po
 			, mFillColor( 1.f, 1.f, 1.f )
 			, mFillColorAnim( ci::Color( 1.f, 1.f, 1.f ) )
 			, mFillEnabled( true )
+			, mShouldIgnoreSuperviewAppliedAlpha( false )
 			, mStrokeColor( 255, 255, 255 )
 			, mStrokeEnabled( false )
 			, mPixelSnapping( false )
@@ -223,7 +224,7 @@ namespace po
 			//	Update our draw order
 			if( hasScene() ) { mDrawOrder = mScene.lock()->getNextDrawOrder(); }
 
-			//	Set applied alpha
+			//	Set applied properties
 			if( hasSuperview() ) {
 				mAppliedAlpha = getSuperview()->getAppliedAlpha() * mAlpha;
 				mAppliedScale = getSuperview()->getAppliedScale() * mScale;
@@ -233,6 +234,11 @@ namespace po
 				mAppliedAlpha = mAlpha;
 				mAppliedScale = mScale;
 				mAppliedRotation = mRotation;
+			}
+
+			//  Ignore applied alpha if specified for custom draw
+			if( mShouldIgnoreSuperviewAppliedAlpha ) {
+				mAppliedAlpha = mAlpha;
 			}
 
 			//	Push our Matrix

--- a/src/poScene/View.cpp
+++ b/src/poScene/View.cpp
@@ -132,7 +132,7 @@ namespace po
 			, mFillColor( 1.f, 1.f, 1.f )
 			, mFillColorAnim( ci::Color( 1.f, 1.f, 1.f ) )
 			, mFillEnabled( true )
-			, mShouldIgnoreSuperviewAppliedAlpha( false )
+			, mIgnoreAppliedAlpha( false )
 			, mStrokeColor( 255, 255, 255 )
 			, mStrokeEnabled( false )
 			, mPixelSnapping( false )
@@ -237,7 +237,7 @@ namespace po
 			}
 
 			//  Ignore applied alpha if specified for custom draw
-			if( mShouldIgnoreSuperviewAppliedAlpha ) {
+			if( mIgnoreAppliedAlpha ) {
 				mAppliedAlpha = mAlpha;
 			}
 

--- a/src/poScene/View.h
+++ b/src/poScene/View.h
@@ -451,10 +451,10 @@ namespace po
 
 				//! Get the applied alpha
 				virtual float getAppliedAlpha() { return mAppliedAlpha; }
-				//! Get if should ignore SuperView's appliedAlpha for custom draw purpose
-				virtual bool getIsIgnoringSuperViewAppliedAlpha() { return mShouldIgnoreSuperviewAppliedAlpha; }
-				//! Set if should ignore SuperView's appliedAlpha for custom draw purpose
-				virtual void setShouldIgnoreSuperViewAppliedAlpha( bool enabled ) { mShouldIgnoreSuperviewAppliedAlpha = enabled; }
+				//! Get if ignoring SuperView's appliedAlph
+				virtual bool getIsIgnoringAppliedAlpha() { return mIgnoreAppliedAlpha; }
+				//! Set if should ignore SuperView's appliedAlpha for custom draw purposes
+				virtual void setIgnoreAppliedAlpha( bool enabled ) { mIgnoreAppliedAlpha = enabled; }
 
 				// Offset
 				// The offset of drawing, relative to the origin.
@@ -724,7 +724,7 @@ namespace po
 				ci::Color mStrokeColor;
 				bool mFillEnabled, mStrokeEnabled;
 				float mAlpha, mAppliedAlpha;
-				bool mShouldIgnoreSuperviewAppliedAlpha;
+				bool mIgnoreAppliedAlpha;
 				MatrixOrder mMatrixOrder;
 
 				bool mPixelSnapping;

--- a/src/poScene/View.h
+++ b/src/poScene/View.h
@@ -507,6 +507,7 @@ namespace po
 				// If the alpha is set to 0.0 the draw call does not execute.
 				virtual View& setBackgroundColor( ci::ColorA color ) { mBackgroundColor = color; return *this; };
 				virtual View& setBackgroundColor( ci::Color color ) { return setBackgroundColor( ci::ColorA( color, 1.0 ) ); };
+				virtual ci::ColorA getBackgroundColor() { return mBackgroundColor; };
 
 				// Fill
 				// This is the color used when drawing the View,

--- a/src/poScene/View.h
+++ b/src/poScene/View.h
@@ -451,6 +451,10 @@ namespace po
 
 				//! Get the applied alpha
 				virtual float getAppliedAlpha() { return mAppliedAlpha; }
+				//! Get if should ignore SuperView's appliedAlpha for custom draw purpose
+				virtual bool getIsIgnoringSuperViewAppliedAlpha() { return mShouldIgnoreSuperviewAppliedAlpha; }
+				//! Set if should ignore SuperView's appliedAlpha for custom draw purpose
+				virtual void setShouldIgnoreSuperViewAppliedAlpha( bool enabled ) { mShouldIgnoreSuperviewAppliedAlpha = enabled; }
 
 				// Offset
 				// The offset of drawing, relative to the origin.
@@ -720,6 +724,7 @@ namespace po
 				ci::Color mStrokeColor;
 				bool mFillEnabled, mStrokeEnabled;
 				float mAlpha, mAppliedAlpha;
+				bool mShouldIgnoreSuperviewAppliedAlpha;
 				MatrixOrder mMatrixOrder;
 
 				bool mPixelSnapping;


### PR DESCRIPTION
### Added methods
- method to ignore mAppliedAlpha
- method to get mBackgroundColor


### Fixed masking blending by implementing `GL_ONE, GL_ONE_MINUS_SRC_ALPHA` in the mixing shader
(this should fix blending artifacts when both layers are transparent)

before `colorLayer.a * maskLayer.a`:
![image](https://user-images.githubusercontent.com/8290363/66869859-41bf2e00-ef6e-11e9-8c6a-a1dcb8d551d7.png)
after: `GL_ONE, GL_ONE_MINUS_SRC_ALPHA`
![image](https://user-images.githubusercontent.com/8290363/66869841-379d2f80-ef6e-11e9-9c67-673b3ab22bdb.png)


